### PR TITLE
Support systemd

### DIFF
--- a/open-ports.service
+++ b/open-ports.service
@@ -1,0 +1,3 @@
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/open_ports.sh

--- a/open-ports.timer
+++ b/open-ports.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Update open-ports' database
+
+[Timer]
+OnCalendar=*-*-* *:0/2
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
On Linux computers, the install script will now first test if systemd is available, before trying to use cron (and won't try to setup cron if it is not available). The changes consist in adding the required systemd files (a timer and a service to be run when the timer ticks), and modifying the Linux install script and the `open_ports.sh` script to make use of systemd if available.

Test plan:
-   Verify that systemd is correctly detected by the install script.
-   Verify that the systemd files were correctly installed by the install script, and that the timer is enabled and running.
-   Verify that the timer ticks every two minutes and does restart automatically after a reboot.
